### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/nrogoff-avanade/50d86c29-d346-4123-af6d-188b0b5e9c8c/f63edfaa-9482-43d3-8747-3697b8b4efc7/_apis/work/boardbadge/4df11f9a-a062-418c-a8b1-923c5cfb13cb)](https://dev.azure.com/nrogoff-avanade/50d86c29-d346-4123-af6d-188b0b5e9c8c/_boards/board/t/f63edfaa-9482-43d3-8747-3697b8b4efc7/Microsoft.RequirementCategory)
 ## Welcome
 
 This repository contains the base project part of our on-site GitHub Verified Partner workshop program. It is meant to be used for in-classroom training under the supervision of GitHub coaches.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#722](https://dev.azure.com/nrogoff-avanade/50d86c29-d346-4123-af6d-188b0b5e9c8c/_workitems/edit/722). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.